### PR TITLE
Add roadmap community plugin and template

### DIFF
--- a/source/plugins/README.md
+++ b/source/plugins/README.md
@@ -59,4 +59,5 @@ Plugins provide additional content and lets you customize rendered metrics.
   * [📸 Website screenshot <sub>`screenshot`</sub>](/source/plugins/community/screenshot/README.md) by [@lowlighter](https://github.com/lowlighter)
   * [🦑 Splatoon <sub>`splatoon`</sub>](/source/plugins/community/splatoon/README.md) by [@lowlighter](https://github.com/lowlighter)
   * [💹 Stock prices <sub>`stock`</sub>](/source/plugins/community/stock/README.md) by [@lowlighter](https://github.com/lowlighter)
+  * [🗺️ Roadmap <sub>`roadmap`</sub>](/source/plugins/community/roadmap/README.md) by [@openai](https://github.com/openai)
 

--- a/source/plugins/community/README.md
+++ b/source/plugins/community/README.md
@@ -54,16 +54,20 @@
       <img alt="" width="400" src="https://github.com/lowlighter/metrics/blob/examples/metrics.plugin.splatoon.svg" alt=""></img>
       <img width="900" height="1" alt="">
     </td>
-  </tr>  <tr>
+  </tr>
+  <tr>
     <th><a href="/source/plugins/community/stock/README.md">💹 Stock prices</a><br><sup>by <a href="https://github.com/lowlighter">@lowlighter</a></sup></th>
-    <th></th>
+    <th><a href="/source/plugins/community/roadmap/README.md">🗺️ Roadmap</a><br><sup>by <a href="https://github.com/openai">@openai</a></sup></th>
   </tr>
   <tr>
     <td  align="center">
       <img alt="" width="400" src="https://github.com/lowlighter/metrics/blob/examples/metrics.plugin.stock.svg" alt=""></img>
       <img width="900" height="1" alt="">
     </td>
-<td align="center"><img width="900" height="1" alt=""></td>
+    <td  align="center">
+      <img alt="" width="400" src="https://via.placeholder.com/468x60?text=No%20preview%20available" alt=""></img>
+      <img width="900" height="1" alt="">
+    </td>
   </tr>
 </table>
 

--- a/source/plugins/community/roadmap/README.md
+++ b/source/plugins/community/roadmap/README.md
@@ -1,0 +1,55 @@
+# 🗺️ Roadmap
+
+Create a compact roadmap diagram to highlight parallel workstreams.
+
+> ℹ️ The rendered result adapts to the labels you provide.
+
+## 🧩 Using this plugin
+
+```yaml
+- name: Roadmap sample
+  uses: lowlighter/metrics@latest
+  with:
+    filename: metrics.plugin.roadmap.svg
+    token: ${{ secrets.METRICS_TOKEN }}
+    base: ''
+    plugin_roadmap: yes
+    plugin_roadmap_title: 2024 product journey
+    plugin_roadmap_main: Discovery, Planning, Development
+    plugin_roadmap_left_title: Validation track
+    plugin_roadmap_left: Prototype, Pilot launch
+    plugin_roadmap_right_title: Fast track
+    plugin_roadmap_right: Quick win
+    plugin_roadmap_final: Launch preparation, Launch
+    plugin_roadmap_palette: modern
+```
+
+## ⚙️ Options
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `plugin_roadmap` | `boolean` | `no` | Enable the roadmap plugin. |
+| `plugin_roadmap_title` | `string` | `Product roadmap` | Section title displayed in the card header. |
+| `plugin_roadmap_main` | `array` | `Discovery, Planning, Development` | List of the first three milestones before the fork. Provide at least three labels. |
+| `plugin_roadmap_left_title` | `string` | `Validation track` | Caption for the upper branch. |
+| `plugin_roadmap_left` | `array` | `Prototype, Pilot launch` | Stops displayed along the upper branch. Provide at least one label. |
+| `plugin_roadmap_right_title` | `string` | `Fast track` | Caption for the lower branch. |
+| `plugin_roadmap_right` | `array` | `Quick win` | Stops displayed along the lower branch. Provide at least one label. |
+| `plugin_roadmap_merge` | `string` | `Converge` | Label placed where the two branches meet again. |
+| `plugin_roadmap_final` | `array` | `Launch preparation, Launch` | Final milestones after the branches converge. Provide at least two labels. |
+| `plugin_roadmap_palette` | `string` | `modern` | Accent palette used for the connectors and nodes. Available values: `modern`, `sunrise`, `ocean`, `monochrome`. |
+
+Each array option expects a comma-separated list when used with action inputs.
+
+## 🎨 Palettes
+
+| Palette | Colors |
+|---------|--------|
+| `modern` | blue mainline, orange upper branch, green lower branch, purple finale |
+| `sunrise` | amber mainline, pink upper branch, violet lower branch, teal finale |
+| `ocean` | teal mainline, cyan upper branch, indigo lower branch, seafoam finale |
+| `monochrome` | Slate greys for all segments |
+
+## ✅ Requirements
+
+This plugin does not require any special token scopes. It works for users, organizations, and repositories alike.

--- a/source/plugins/community/roadmap/examples.yml
+++ b/source/plugins/community/roadmap/examples.yml
@@ -1,0 +1,15 @@
+- name: Roadmap
+  uses: lowlighter/metrics@latest
+  with:
+    filename: metrics.plugin.roadmap.svg
+    token: ${{ secrets.METRICS_TOKEN }}
+    base: ''
+    plugin_roadmap: yes
+    plugin_roadmap_title: Feature rollout
+    plugin_roadmap_main: Discovery, Planning, Development
+    plugin_roadmap_left_title: Validation track
+    plugin_roadmap_left: Prototype, Pilot launch
+    plugin_roadmap_right_title: Fast track
+    plugin_roadmap_right: Quick win
+    plugin_roadmap_final: Launch preparation, Launch
+    plugin_roadmap_palette: modern

--- a/source/plugins/community/roadmap/index.mjs
+++ b/source/plugins/community/roadmap/index.mjs
@@ -1,0 +1,63 @@
+export default async function({data, q, imports, account}, {enabled = false, extras = false} = {}) {
+  try {
+    if ((!q.roadmap) || (!imports.metadata.plugins.roadmap.enabled(enabled, {extras})))
+      return null
+
+    let {
+      title,
+      main,
+      left_title: leftTitle,
+      left,
+      right_title: rightTitle,
+      right,
+      merge,
+      final,
+      palette,
+    } = imports.metadata.plugins.roadmap.inputs({data, account, q})
+
+    const normalize = value => (Array.isArray(value) ? value.map(item => `${item}`.trim()).filter(Boolean) : [])
+
+    title = `${title ?? ""}`.trim() || "Product roadmap"
+    leftTitle = `${leftTitle ?? ""}`.trim()
+    rightTitle = `${rightTitle ?? ""}`.trim()
+    merge = `${merge ?? ""}`.trim()
+
+    main = normalize(main)
+    left = normalize(left)
+    right = normalize(right)
+    final = normalize(final)
+
+    if (main.length < 3)
+      throw {error: {message: "At least 3 main stops are required"}}
+    if (left.length < 1)
+      throw {error: {message: "Upper branch needs at least 1 stop"}}
+    if (right.length < 1)
+      throw {error: {message: "Lower branch needs at least 1 stop"}}
+    if (final.length < 2)
+      throw {error: {message: "Final stage requires at least 2 stops"}}
+
+    const palettes = {
+      modern: {main: "#2563eb", left: "#f97316", right: "#10b981", final: "#7c3aed"},
+      sunrise: {main: "#f59e0b", left: "#f973ab", right: "#8b5cf6", final: "#14b8a6"},
+      ocean: {main: "#0ea5e9", left: "#22d3ee", right: "#6366f1", final: "#34d399"},
+      monochrome: {main: "#475569", left: "#475569", right: "#475569", final: "#475569"},
+    }
+
+    const selectedPalette = palettes[palette] ?? palettes.modern
+
+    return {
+      title,
+      main,
+      branches: {
+        left: {title: leftTitle, stops: left},
+        right: {title: rightTitle, stops: right},
+      },
+      final,
+      merge,
+      palette: selectedPalette,
+    }
+  }
+  catch (error) {
+    throw imports.format.error(error)
+  }
+}

--- a/source/plugins/community/roadmap/metadata.yml
+++ b/source/plugins/community/roadmap/metadata.yml
@@ -1,0 +1,86 @@
+name: 🗺️ Roadmap
+category: community
+description: |
+  This plugin renders a lightweight roadmap diagram with a branching decision point.
+  It is useful for communicating high-level plans directly from your metrics card.
+authors:
+  - openai
+supports:
+  - user
+  - organization
+  - repository
+scopes: []
+inputs:
+
+  plugin_roadmap:
+    description: |
+      Enable roadmap plugin
+    type: boolean
+    default: no
+
+  plugin_roadmap_title:
+    description: |
+      Section title displayed above the roadmap
+    type: string
+    default: Product roadmap
+
+  plugin_roadmap_main:
+    description: |
+      Sequential stops before the fork
+    type: array
+    format: comma-separated
+    default: Discovery, Planning, Development
+    minItems: 3
+
+  plugin_roadmap_left_title:
+    description: |
+      Label for the upper branch
+    type: string
+    default: Validation track
+
+  plugin_roadmap_left:
+    description: |
+      Stops displayed on the upper branch (should include at least one more stop than the lower branch)
+    type: array
+    format: comma-separated
+    default: Prototype, Pilot launch
+    minItems: 1
+
+  plugin_roadmap_right_title:
+    description: |
+      Label for the lower branch
+    type: string
+    default: Fast track
+
+  plugin_roadmap_right:
+    description: |
+      Stops displayed on the lower branch
+    type: array
+    format: comma-separated
+    default: Quick win
+    minItems: 1
+
+  plugin_roadmap_merge:
+    description: |
+      Label placed where the two branches converge
+    type: string
+    default: Converge
+
+  plugin_roadmap_final:
+    description: |
+      Final stops after both branches converge
+    type: array
+    format: comma-separated
+    default: Launch preparation, Launch
+    minItems: 2
+
+  plugin_roadmap_palette:
+    description: |
+      Color palette used for the roadmap accents
+    type: string
+    default: modern
+    values:
+      - modern
+      - sunrise
+      - ocean
+      - monochrome

--- a/source/templates/classic/partials/_.json
+++ b/source/templates/classic/partials/_.json
@@ -43,6 +43,7 @@
   "sponsorships",
   "poopmap",
   "16personalities",
+  "roadmap",
   "fortune",
   "splatoon",
   "steam"

--- a/source/templates/classic/partials/roadmap.ejs
+++ b/source/templates/classic/partials/roadmap.ejs
@@ -1,0 +1,101 @@
+<% if (plugins.roadmap) { %>
+  <section class="roadmap">
+    <h2 class="field">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M5.22 1.22a.75.75 0 011.06 0l1.22 1.22h2.5a1.5 1.5 0 011.342.833l1.233 2.465h1.175a.75.75 0 010 1.5h-1.75a.75.75 0 01-.671-.413l-1.425-2.85H8.5a.75.75 0 01-.53-.22L6.72 2.78 4.28 5.22 5.5 6.44a.75.75 0 010 1.06l-3 3a.75.75 0 01-1.06-1.06l2.47-2.47L2.47 5.72a.75.75 0 010-1.06l2.75-2.75zM9 8.75a.75.75 0 01.75-.75h1.5a.75.75 0 010 1.5H9.75A.75.75 0 019 8.75zm-2 3.5A.75.75 0 017.75 11.5h3.5a.75.75 0 010 1.5h-3.5A.75.75 0 017 12.25zm5 0a.75.75 0 01.75-.75h1a.75.75 0 010 1.5h-1a.75.75 0 01-.75-.75z"></path></svg>
+      <%= plugins.roadmap.title %>
+    </h2>
+    <% if (plugins.roadmap.error) { %>
+      <div class="row">
+        <section>
+          <div class="field error">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M2.343 13.657A8 8 0 1113.657 2.343 8 8 0 012.343 13.657zM6.03 4.97a.75.75 0 10-1.06 1.06L6.94 8 4.97 9.97a.75.75 0 101.06 1.06L8 9.06l1.97 1.97a.75.75 0 101.06-1.06L9.06 8l1.97-1.97a.75.75 0 10-1.06-1.06L8 6.94 6.03 4.97z"></path></svg>
+            <%= plugins.roadmap.error.message %>
+          </div>
+        </section>
+      </div>
+    <% } else { %>
+      <%
+        const data = plugins.roadmap
+        const left = data.branches?.left ?? {title: "", stops: []}
+        const right = data.branches?.right ?? {title: "", stops: []}
+        const margin = 60
+        const spacing = 100
+        const baseY = 120
+        const branchOffset = 60
+        const leftY = baseY - branchOffset
+        const rightY = baseY + branchOffset
+        const branchMax = Math.max(left.stops.length, right.stops.length, 1)
+        const forkX = margin + (data.main.length - 1) * spacing
+        const convergeX = forkX + spacing * (branchMax + 1)
+        const mainNodes = data.main.map((label, index) => ({label, x: margin + index * spacing, y: baseY}))
+        const leftNodes = left.stops.map((label, index) => ({label, x: forkX + spacing * (index + 1), y: leftY}))
+        const rightNodes = right.stops.map((label, index) => ({label, x: forkX + spacing * (index + 1), y: rightY}))
+        const finalNodes = data.final.map((label, index) => ({label, x: convergeX + spacing * (index + 1), y: baseY}))
+        const width = (finalNodes.length ? finalNodes[finalNodes.length - 1].x : convergeX) + margin
+        const height = 220
+        const convergePoint = {x: convergeX, y: baseY}
+        const mainPath = mainNodes.map(({x, y}, index) => `${index ? "L" : "M"} ${x} ${y}`).join(" ")
+        const leftPath = leftNodes.length
+          ? `M ${forkX} ${baseY} C ${forkX + spacing / 2} ${baseY - branchOffset / 2}, ${leftNodes[0].x - spacing / 2} ${leftY}, ${leftNodes[0].x} ${leftY}`
+            + leftNodes.slice(1).map(({x, y}) => ` L ${x} ${y}`).join("")
+            + ` C ${leftNodes[leftNodes.length - 1].x + spacing / 2} ${leftY}, ${convergePoint.x - spacing / 2} ${baseY - branchOffset / 2}, ${convergePoint.x} ${convergePoint.y}`
+          : ""
+        const rightPath = rightNodes.length
+          ? `M ${forkX} ${baseY} C ${forkX + spacing / 2} ${baseY + branchOffset / 2}, ${rightNodes[0].x - spacing / 2} ${rightY}, ${rightNodes[0].x} ${rightY}`
+            + rightNodes.slice(1).map(({x, y}) => ` L ${x} ${y}`).join("")
+            + ` C ${rightNodes[rightNodes.length - 1].x + spacing / 2} ${rightY}, ${convergePoint.x - spacing / 2} ${baseY + branchOffset / 2}, ${convergePoint.x} ${convergePoint.y}`
+          : ""
+        const finalPath = finalNodes.length
+          ? `M ${convergePoint.x} ${convergePoint.y}` + finalNodes.map(({x, y}) => ` L ${x} ${y}`).join("")
+          : ""
+      %>
+      <div class="roadmap__wrapper" style="--roadmap-color-main: <%= data.palette.main %>; --roadmap-color-left: <%= data.palette.left %>; --roadmap-color-right: <%= data.palette.right %>; --roadmap-color-final: <%= data.palette.final %>;">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 <%= width %> <%= height %>" width="100%" height="100%" preserveAspectRatio="xMidYMid meet">
+          <% if (mainPath) { %>
+            <path class="roadmap__path roadmap__path--main" d="<%= mainPath %>" />
+          <% } %>
+          <% if (leftPath) { %>
+            <path class="roadmap__path roadmap__path--left" d="<%= leftPath %>" />
+          <% } %>
+          <% if (rightPath) { %>
+            <path class="roadmap__path roadmap__path--right" d="<%= rightPath %>" />
+          <% } %>
+          <% if (finalPath) { %>
+            <path class="roadmap__path roadmap__path--final" d="<%= finalPath %>" />
+          <% } %>
+
+          <% for (const node of mainNodes) { %>
+            <circle class="roadmap__node roadmap__node--main" cx="<%= node.x %>" cy="<%= node.y %>" r="12" />
+            <text class="roadmap__label roadmap__label--main" x="<%= node.x %>" y="<%= node.y + 28 %>"><%= node.label %></text>
+          <% } %>
+
+          <% if (leftNodes.length && left.title) { %>
+            <text class="roadmap__label roadmap__label--branch" x="<%= leftNodes[0].x %>" y="<%= leftY - 22 %>"><%= left.title %></text>
+          <% } %>
+          <% for (const node of leftNodes) { %>
+            <circle class="roadmap__node roadmap__node--left" cx="<%= node.x %>" cy="<%= node.y %>" r="10" />
+            <text class="roadmap__label roadmap__label--branch-stop" x="<%= node.x %>" y="<%= node.y - 18 %>"><%= node.label %></text>
+          <% } %>
+
+          <% if (rightNodes.length && right.title) { %>
+            <text class="roadmap__label roadmap__label--branch" x="<%= rightNodes[0].x %>" y="<%= rightY + 32 %>"><%= right.title %></text>
+          <% } %>
+          <% for (const node of rightNodes) { %>
+            <circle class="roadmap__node roadmap__node--right" cx="<%= node.x %>" cy="<%= node.y %>" r="10" />
+            <text class="roadmap__label roadmap__label--branch-stop" x="<%= node.x %>" y="<%= node.y + 26 %>"><%= node.label %></text>
+          <% } %>
+
+          <circle class="roadmap__node roadmap__node--merge" cx="<%= convergePoint.x %>" cy="<%= convergePoint.y %>" r="9" />
+          <% if (data.merge) { %>
+            <text class="roadmap__label roadmap__label--merge" x="<%= convergePoint.x %>" y="<%= convergePoint.y - 24 %>"><%= data.merge %></text>
+          <% } %>
+
+          <% for (const node of finalNodes) { %>
+            <circle class="roadmap__node roadmap__node--final" cx="<%= node.x %>" cy="<%= node.y %>" r="12" />
+            <text class="roadmap__label roadmap__label--final" x="<%= node.x %>" y="<%= node.y + 28 %>"><%= node.label %></text>
+          <% } %>
+        </svg>
+      </div>
+    <% } %>
+  </section>
+<% } %>

--- a/source/templates/classic/style.css
+++ b/source/templates/classic/style.css
@@ -1654,6 +1654,70 @@
     --color-calendar-graph-day-L1-border: rgba(27,31,35,0.06);
   }
 
+/* Roadmap */
+  .roadmap__wrapper {
+    margin: 8px 0 0;
+  }
+  .roadmap__path {
+    fill: none;
+    stroke-width: 6px;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    opacity: 0.9;
+  }
+  .roadmap__path--main {
+    stroke: var(--roadmap-color-main);
+  }
+  .roadmap__path--left {
+    stroke: var(--roadmap-color-left);
+  }
+  .roadmap__path--right {
+    stroke: var(--roadmap-color-right);
+  }
+  .roadmap__path--final {
+    stroke: var(--roadmap-color-final);
+  }
+  .roadmap__node {
+    fill: #ffffff;
+    stroke-width: 3px;
+  }
+  .roadmap__node--main {
+    stroke: var(--roadmap-color-main);
+  }
+  .roadmap__node--left {
+    stroke: var(--roadmap-color-left);
+  }
+  .roadmap__node--right {
+    stroke: var(--roadmap-color-right);
+  }
+  .roadmap__node--merge,
+  .roadmap__node--final {
+    stroke: var(--roadmap-color-final);
+  }
+  .roadmap__label {
+    fill: #2f363d;
+    text-anchor: middle;
+  }
+  .roadmap__label--main,
+  .roadmap__label--final {
+    font-size: 12px;
+    font-weight: 600;
+  }
+  .roadmap__label--branch {
+    font-size: 12px;
+    font-weight: 600;
+    fill: #4b5563;
+  }
+  .roadmap__label--branch-stop {
+    font-size: 11px;
+    fill: #4c4c4c;
+  }
+  .roadmap__label--merge {
+    font-size: 11px;
+    font-weight: 600;
+    fill: var(--roadmap-color-final);
+  }
+
 /* End delimiter */
   #metrics-end {
     width: 100%;


### PR DESCRIPTION
## Summary
- add a community roadmap plugin with metadata, docs, and examples
- render the roadmap graphic in the classic template with a dedicated partial and styles
- document the new plugin in the community plugin listings

## Testing
- npm run linter

------
https://chatgpt.com/codex/tasks/task_e_68dec49d1aa08331998329ad9882658a